### PR TITLE
feat(cover): add cover parse

### DIFF
--- a/test/ginny/changelog_test.clj
+++ b/test/ginny/changelog_test.clj
@@ -221,6 +221,9 @@
                                       "- Added another feature"
                                       "- Added third feature"
                                       ""
+                                      "## Cover"
+                                      "[![hello](http://bearychat.com/static/cover.png)](http://bearychat.com)"
+                                      ""
                                       "# 2.0.0 / 2016-11-24"
                                       "## Client"
                                       "### 32bit"
@@ -236,7 +239,10 @@
                                       ""
                                       "## Added"
                                       "- Added a feature1"
-                                      "- Added another feature2"])
+                                      "- Added another feature2"
+                                      ""
+                                      "## Cover"
+                                      "![](http://static.qiniu.com/png/123sa.png)"])
             changelog (parse md)]
         (is (= (count changelog) 2))
         (is (= (:header changelog) {:name "bearychat"
@@ -258,7 +264,10 @@
                                     "Fixed another bug")
                            :added '("Added a feature"
                                     "Added another feature"
-                                    "Added third feature")}))
+                                    "Added third feature")
+                           :cover '{:link "http://bearychat.com"
+                                    :image_text "hello"
+                                    :image_url "http://bearychat.com/static/cover.png"}}))
         (is (= (-> changelog
                    :body
                    :releases
@@ -270,4 +279,7 @@
                                              :downloadurl "http://bearychat.com/old/64bit.exe"}}
                             :fixed '("Fixed a bug1")
                             :added '("Added a feature1"
-                                     "Added another feature2")}))))))
+                                     "Added another feature2")
+                            :cover '{:link nil
+                                      :image_text ""
+                                      :image_url "http://static.qiniu.com/png/123sa.png"}}))))))


### PR DESCRIPTION
- 解析 `changelogs` 中的 `Cover` 字段，将其内容解析为
```clojure
{:image_text "image_text"
 :image_url "image_url"
 :link "link"}
```

example:
```clojure
    [![Build Status](https://travis-ci.org/trekhleb/javascript-algorithms.svg?branch=master)](https://travis-ci.org/trekhleb/javascript-algorithms)
    {:image_text "Build Status", :image_url "https://travis-ci.org/trekhleb/javascript-algorithms.svg?branch=master", :link "https://travis-ci.org/trekhleb/javascript-algorithms"}
```

```clojure
    ![Build Status](https://travis-ci.org/trekhleb/javascript-algorithms.svg?branch=master)
    {:image_text "Build Status", :image_url "https://travis-ci.org/trekhleb/javascript-algorithms.svg?branch=master", :link nil}
```